### PR TITLE
[DLS-7268] Fixed CORS issue - moved CORS policy from application to endpoint

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,11 +39,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
 
-play.filters.enabled += "play.filters.cors.CORSFilter"
-play.filters.cors {
-  allowedOrigins = ["http://localhost:9680"]
-}
-
 # Play Modules
 # ~~~~
 # Additional play modules can be added here

--- a/conf/definition.routes
+++ b/conf/definition.routes
@@ -1,3 +1,3 @@
 GET    /api/definition                              uk.gov.hmrc.individualsmatchingapi.controllers.DocumentationController.definition()
 GET    /api/documentation/:version/:endpointName    uk.gov.hmrc.individualsmatchingapi.controllers.DocumentationController.documentation(version,endpointName)
-GET    /api/conf/:version/*file                     uk.gov.hmrc.individualsmatchingapi.controllers.DocumentationController.raml(version, file)
+GET    /api/conf/:version/*file                     uk.gov.hmrc.individualsmatchingapi.controllers.DocumentationController.specification(version, file)


### PR DESCRIPTION
This fix aims to address the issue caused by the RAML to OAS migration of individuals-matching-api after it was reporting failures shortly after deployment.

We believe this was due to an oversight on the CORS policy.

For reviewers:
Unit tests pass
Locally verified