### PR TITLE
Gaja/DLS 11629/scala 3 upgrade

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,7 +2,7 @@ style = defaultWithAlign
 maxColumn = 120
 lineEndings = unix
 importSelectors = singleLine
-runner.dialect = scala213
+runner.dialect = scala3
 version = 3.7.13
 
 project {

--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 This API allows users to check HMRC records to find information about an individual.
 
 ### Documentation
+
 The documentation on [confluence](https://confluence.tools.tax.service.gov.uk/display/MDS/Development+space) includes:
+
 - Configuration driven management of data and scopes
 - Scope driven query strings for Integration Framework (IF)
 - Caching strategy to alleviate load on backend systems
 
-Please ensure you reference the OGD Data Item matrix to ensure the right data items are mapped and keep this document up to date if further data items are added.
+Please ensure you reference the OGD Data Item matrix to ensure the right data items are mapped and keep this document up
+to date if further data items are added.
 (The matrix was last validated at V1.1, please ensure you update with any changes you make.)
 
 ### Running tests
@@ -19,4 +22,5 @@ Unit, integration and component tests can be run with the following:
 
 ### License
 
-This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html")
+This code is open source software licensed under
+the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html")

--- a/app/uk/gov/hmrc/individualsmatchingapi/config/ConfigModule.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/config/ConfigModule.scala
@@ -17,13 +17,12 @@
 package uk.gov.hmrc.individualsmatchingapi.config
 
 import com.google.inject.AbstractModule
-import play.api.{Configuration, Environment}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 import uk.gov.hmrc.play.bootstrap.http.HttpClientV2Provider
 
-class ConfigModule(environment: Environment, configuration: Configuration) extends AbstractModule {
+class ConfigModule extends AbstractModule {
   override def configure(): Unit = {
     bind(classOf[HttpClientV2]).toProvider(classOf[HttpClientV2Provider])
     bind(classOf[AuthConnector]).to(classOf[DefaultAuthConnector])

--- a/app/uk/gov/hmrc/individualsmatchingapi/config/IndividualMatchingApiRequestHandler.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/config/IndividualMatchingApiRequestHandler.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{Handler, RequestHeader}
 import play.api.routing.Router
 import play.api.{Configuration, OptionalDevContext}
 import play.core.WebCommands
-import uk.gov.hmrc.individualsmatchingapi.play.RequestHeaderUtils._
+import uk.gov.hmrc.individualsmatchingapi.play.RequestHeaderUtils.*
 import uk.gov.hmrc.play.bootstrap.http.RequestHandler
 
 import javax.inject.Inject

--- a/app/uk/gov/hmrc/individualsmatchingapi/connectors/CitizenDetailsConnector.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/connectors/CitizenDetailsConnector.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsmatchingapi.connectors
 
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.UpstreamErrorResponse.Upstream5xxResponse
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps, UpstreamErrorResponse}

--- a/app/uk/gov/hmrc/individualsmatchingapi/connectors/MatchingConnector.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/connectors/MatchingConnector.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.individualsmatchingapi.connectors
 import play.api.libs.json.Json
-import play.api.libs.ws.JsonBodyWritables._
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import play.api.libs.ws.JsonBodyWritables.*
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.detailsMatchRequestFormat

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/CommonController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/CommonController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.individualsmatchingapi.controllers
 
 import play.api.Logging
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{ControllerComponents, Request, RequestHeader, Result}
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
@@ -25,7 +25,7 @@ import uk.gov.hmrc.auth.core.{AuthorisationException, AuthorisedFunctions, Enrol
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, TooManyRequestException}
 import uk.gov.hmrc.individualsmatchingapi.audit.AuditHelper
 import uk.gov.hmrc.individualsmatchingapi.controllers.Environment.SANDBOX
-import uk.gov.hmrc.individualsmatchingapi.domain._
+import uk.gov.hmrc.individualsmatchingapi.domain.*
 import uk.gov.hmrc.individualsmatchingapi.utils.UuidValidator
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/CommonController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/CommonController.scala
@@ -33,13 +33,14 @@ import java.util.UUID
 import javax.inject.Inject
 import scala.concurrent.Future.successful
 import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 abstract class CommonController @Inject() (cc: ControllerComponents) extends BackendController(cc) with Logging {
 
   override protected def withJsonBody[T](
     f: T => Future[Result]
-  )(implicit request: Request[JsValue], m: Manifest[T], reads: Reads[T]): Future[Result] =
+  )(implicit request: Request[JsValue], m: ClassTag[T], reads: Reads[T]): Future[Result] =
     Try(request.body.validate[T]) match {
       case Success(JsSuccess(payload, _)) => f(payload)
       case Success(JsError(errs)) =>

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/DocumentationController.scala
@@ -23,7 +23,7 @@ import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import play.filters.cors.CORSActionBuilder
-import uk.gov.hmrc.individualsmatchingapi.views._
+import uk.gov.hmrc.individualsmatchingapi.views.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingController.scala
@@ -19,10 +19,10 @@ package uk.gov.hmrc.individualsmatchingapi.controllers.v1
 import play.api.hal.Hal.links
 import play.api.hal.HalLink
 import play.api.libs.json.JsValue
-import play.api.mvc.hal._
+import play.api.mvc.hal.*
 import play.api.mvc.{Action, ControllerComponents}
-import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.individualsmatchingapi.controllers.Environment._
+import uk.gov.hmrc.auth.core.*
+import uk.gov.hmrc.individualsmatchingapi.controllers.Environment.*
 import uk.gov.hmrc.individualsmatchingapi.controllers.{CommonController, PrivilegedAuthentication}
 import uk.gov.hmrc.individualsmatchingapi.domain.CitizenMatchingRequest
 import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.citizenMatchingFormat

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedIndividualsController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedIndividualsController.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.individualsmatchingapi.controllers.v1
 
-import play.api.hal.Hal._
+import play.api.hal.Hal.*
 import play.api.hal.HalLink
 import play.api.libs.json.Json.{obj, toJson}
-import play.api.mvc.hal._
+import play.api.mvc.hal.*
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.individualsmatchingapi.controllers.Environment._
+import uk.gov.hmrc.individualsmatchingapi.controllers.Environment.*
 import uk.gov.hmrc.individualsmatchingapi.controllers.{CommonController, PrivilegedAuthentication}
 import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.citizenDetailsFormat
 import uk.gov.hmrc.individualsmatchingapi.services.{CitizenMatchingService, LiveCitizenMatchingService, SandboxCitizenMatchingService}

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingController.scala
@@ -16,17 +16,17 @@
 
 package uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
+import play.api.hal.*
 import play.api.hal.Hal.links
-import play.api.hal.HalLink
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.hal.*
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.individualsmatchingapi.audit.AuditHelper
-import uk.gov.hmrc.individualsmatchingapi.controllers.Environment._
+import uk.gov.hmrc.individualsmatchingapi.controllers.Environment.*
 import uk.gov.hmrc.individualsmatchingapi.controllers.{CommonController, PrivilegedAuthentication}
 import uk.gov.hmrc.individualsmatchingapi.domain.CitizenMatchingRequest
-import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters._
+import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.*
 import uk.gov.hmrc.individualsmatchingapi.play.RequestHeaderUtils.{maybeCorrelationId, validateCorrelationId}
 import uk.gov.hmrc.individualsmatchingapi.services.{LiveCitizenMatchingService, ScopesService}
 

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingController.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.individualsmatchingapi.controllers.v2
 import play.api.hal.Hal.links
 import play.api.hal.HalLink
 import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.hal._
+import play.api.mvc.hal.*
 import play.api.mvc.{Action, ControllerComponents}
-import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.individualsmatchingapi.audit.AuditHelper
 import uk.gov.hmrc.individualsmatchingapi.controllers.Environment._
 import uk.gov.hmrc.individualsmatchingapi.controllers.{CommonController, PrivilegedAuthentication}

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsController.scala
@@ -16,15 +16,15 @@
 
 package uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
+import play.api.hal.*
 import play.api.hal.Hal.state
 import play.api.libs.json.Json
 import play.api.libs.json.Json.{obj, toJson}
-import play.api.hal.*
 import play.api.mvc.hal.*
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.individualsmatchingapi.audit.AuditHelper
-import uk.gov.hmrc.individualsmatchingapi.controllers.Environment._
+import uk.gov.hmrc.individualsmatchingapi.controllers.Environment.*
 import uk.gov.hmrc.individualsmatchingapi.controllers.{CommonController, PrivilegedAuthentication}
 import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.citizenDetailsFormat
 import uk.gov.hmrc.individualsmatchingapi.play.RequestHeaderUtils.{maybeCorrelationId, validateCorrelationId}

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
 import play.api.hal.Hal.state
-import play.api.hal.HalLink
+import play.api.hal.{HalLink, HalResource}
 import play.api.libs.json.Json
 import play.api.libs.json.Json.{obj, toJson}
 import play.api.mvc.hal._

--- a/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsController.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsController.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
 import play.api.hal.Hal.state
-import play.api.hal.{HalLink, HalResource}
 import play.api.libs.json.Json
 import play.api.libs.json.Json.{obj, toJson}
-import play.api.mvc.hal._
+import play.api.hal.*
+import play.api.mvc.hal.*
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.individualsmatchingapi.audit.AuditHelper

--- a/app/uk/gov/hmrc/individualsmatchingapi/domain/CitizenMatching.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/domain/CitizenMatching.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.individualsmatchingapi.domain
 
-import java.time.LocalDate
 import uk.gov.hmrc.domain.Nino
 
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.util.Try

--- a/app/uk/gov/hmrc/individualsmatchingapi/domain/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/domain/ErrorResponses.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.individualsmatchingapi.domain
 
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.libs.json.Json
 import play.api.mvc.{Result, Results}
-import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters._
+import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.*
 
 sealed abstract class ErrorResponse(val httpStatusCode: Int, val errorCode: String, val message: String) {
 

--- a/app/uk/gov/hmrc/individualsmatchingapi/domain/Individual.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/domain/Individual.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.individualsmatchingapi.domain
 import uk.gov.hmrc.domain.Nino
 
 import java.time.LocalDate
-import java.time.LocalDate._
+import java.time.LocalDate.*
 import java.util.UUID
 
 case class Individual(matchId: UUID, nino: String, firstName: String, lastName: String, dateOfBirth: LocalDate)

--- a/app/uk/gov/hmrc/individualsmatchingapi/domain/Individual.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/domain/Individual.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.individualsmatchingapi.domain
 
-import java.time.LocalDate
-import java.time.LocalDate._
 import uk.gov.hmrc.domain.Nino
 
+import java.time.LocalDate
+import java.time.LocalDate._
 import java.util.UUID
 
 case class Individual(matchId: UUID, nino: String, firstName: String, lastName: String, dateOfBirth: LocalDate)

--- a/app/uk/gov/hmrc/individualsmatchingapi/domain/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/domain/JsonFormatters.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.individualsmatchingapi.domain
 
-import java.time.LocalDate
 import play.api.libs.json._
 
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 

--- a/app/uk/gov/hmrc/individualsmatchingapi/domain/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/domain/JsonFormatters.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsmatchingapi.domain
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter

--- a/app/uk/gov/hmrc/individualsmatchingapi/repository/NinoMatchRepository.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/repository/NinoMatchRepository.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.individualsmatchingapi.repository
 
+import org.mongodb.scala.SingleObservableFuture
 import org.mongodb.scala.model.Indexes.ascending
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions}
 import play.api.Configuration

--- a/app/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingService.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingService.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.individualsmatchingapi.services
 
-import java.time.LocalDate
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsmatchingapi.connectors.{CitizenDetailsConnector, MatchingConnector}
 import uk.gov.hmrc.individualsmatchingapi.domain._
 import uk.gov.hmrc.individualsmatchingapi.repository.NinoMatchRepository
 
+import java.time.LocalDate
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future.{failed, successful}

--- a/app/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingService.scala
+++ b/app/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.individualsmatchingapi.services
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsmatchingapi.connectors.{CitizenDetailsConnector, MatchingConnector}
-import uk.gov.hmrc.individualsmatchingapi.domain._
+import uk.gov.hmrc.individualsmatchingapi.domain.*
 import uk.gov.hmrc.individualsmatchingapi.repository.NinoMatchRepository
 
 import java.time.LocalDate

--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,10 @@ lazy val ItTest = config("it") extend Test
 lazy val microservice =
   Project(appName, file("."))
     .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
-    .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
+    .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
     .settings(onLoadMessage := "")
     .settings(CodeCoverageSettings.settings *)
-    .settings(scalaVersion := "2.13.16")
+    .settings(scalaVersion := "3.3.5")
     .settings(scalafmtOnCompile := true)
     .settings(
       libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test()
@@ -33,7 +33,8 @@ lazy val microservice =
         "-u",
         "target/int-test-reports",
         "-h",
-        "target/int-test-reports/html-report")
+        "target/int-test-reports/html-report"
+      )
     )
     .configs(ComponentTest)
     .settings(inConfig(ComponentTest)(Defaults.testSettings) *)
@@ -49,7 +50,8 @@ lazy val microservice =
         "-u",
         "target/component-test-reports",
         "-h",
-        "target/component-test-reports/html-report")
+        "target/component-test-reports/html-report"
+      )
     )
     .settings(majorVersion := 0)
     .settings(
@@ -59,14 +61,19 @@ lazy val microservice =
     .settings(PlayKeys.playDefaultPort := 9653)
     .settings(Test / testOptions := Seq(Tests.Filter((name: String) => name.startsWith("unit"))))
     // Disable default sbt Test options (might change with new versions of bootstrap)
-    .settings(Test / testOptions -= Tests
-      .Argument("-o", "-u", "target/test-reports", "-h", "target/test-reports/html-report"))
+    .settings(
+      Test / testOptions -= Tests
+        .Argument("-o", "-u", "target/test-reports", "-h", "target/test-reports/html-report")
+    )
     // Suppress successful events in Scalatest in standard output (-o)
     // Options described here: https://www.scalatest.org/user_guide/using_scalatest_with_sbt
-    .settings(Test / testOptions += Tests.Argument(
-      TestFrameworks.ScalaTest,
-      "-oNCHPQR",
-      "-u",
-      "target/test-reports",
-      "-h",
-      "target/test-reports/html-report"))
+    .settings(
+      Test / testOptions += Tests.Argument(
+        TestFrameworks.ScalaTest,
+        "-oNCHPQR",
+        "-u",
+        "target/test-reports",
+        "-h",
+        "target/test-reports/html-report"
+      )
+    )

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val microservice =
     .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
     .settings(onLoadMessage := "")
     .settings(CodeCoverageSettings.settings *)
-    .settings(scalaVersion := "2.13.12")
+    .settings(scalaVersion := "2.13.16")
     .settings(scalafmtOnCompile := true)
     .settings(
       libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test()

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val microservice =
     .settings(majorVersion := 0)
     .settings(
       scalacOptions += "-Wconf:src=routes/.*:s",
-      scalacOptions += "-Wconf:cat=unused-imports&src=txt/.*:s"
+      scalacOptions += "-Wconf:msg=unused-imports&src=txt/.*:s"
     )
     .settings(PlayKeys.playDefaultPort := 9653)
     .settings(Test / testOptions := Seq(Tests.Filter((name: String) => name.startsWith("unit"))))

--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,7 @@ lazy val microservice =
     )
     .settings(majorVersion := 0)
     .settings(
-      scalacOptions += "-Wconf:src=routes/.*:s,src=txt/.*:s",
-      scalacOptions += "-Wunused:imports"
+      scalacOptions += "-Wconf:src=routes/.*:s,src=txt/.*:s"
     )
     .settings(PlayKeys.playDefaultPort := 9653)
     .settings(Test / testOptions := Seq(Tests.Filter((name: String) => name.startsWith("unit"))))

--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,8 @@ lazy val microservice =
     )
     .settings(majorVersion := 0)
     .settings(
-      scalacOptions += "-Wconf:src=routes/.*:s",
-      scalacOptions += "-Wconf:msg=unused-imports&src=txt/.*:s"
+      scalacOptions += "-Wconf:src=routes/.*:s,src=txt/.*:s",
+      scalacOptions += "-Wunused:imports"
     )
     .settings(PlayKeys.playDefaultPort := 9653)
     .settings(Test / testOptions := Seq(Tests.Filter((name: String) => name.startsWith("unit"))))

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -4,13 +4,17 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/individuals-matching-api.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message]
+                %replace(exception=[%xException]){'^exception=\[\]$',''}%n
+            </pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}]
+                user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,16 +10,16 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     hmrc      %% s"bootstrap-backend-$playVersion" % hmrcBootstrapVersion,
-    hmrc      %% s"domain-$playVersion"            % "9.0.0",
-    hmrc      %% s"play-hal-$playVersion"          % "4.0.0", // for scala 3
+    hmrc      %% s"domain-$playVersion"            % "11.0.0",
+    hmrc      %% s"play-hal-$playVersion"          % "4.1.0",
     hmrcMongo %% s"hmrc-mongo-$playVersion"        % hmrcMongoVersion
   )
 
   def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
-    hmrc                   %% s"bootstrap-test-$playVersion" % hmrcBootstrapVersion % scope,
-    //"org.mockito"          %% "mockito-scala"                % "1.17.37"            % scope,
-   // "org.scalatestplus"    %% "mockito-4-11"                 % "3.2.17.0"           %scope,
-    "org.scalatestplus"    %% "scalacheck-1-17"              % "3.2.18.0"           % scope,
-    "com.codacy"           %% "scalaj-http"                  % "2.5.0"              % scope,
+    hmrc %% s"bootstrap-test-$playVersion" % hmrcBootstrapVersion % scope,
+    // "org.mockito"          %% "mockito-scala"                % "1.17.37"            % scope,
+    // "org.scalatestplus"    %% "mockito-4-11"                 % "3.2.17.0"           %scope,
+    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.18.0" % scope,
+    "com.codacy"        %% "scalaj-http"     % "2.5.0"    % scope
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,20 +5,21 @@ object AppDependencies {
 
   val hmrcMongo = s"$hmrc.mongo"
   val playVersion = "play-30"
-  val hmrcMongoVersion = "1.7.0"
-  val hmrcBootstrapVersion = "9.0.0"
+  val hmrcMongoVersion = "2.6.0"
+  val hmrcBootstrapVersion = "9.11.0"
 
   val compile: Seq[ModuleID] = Seq(
     hmrc      %% s"bootstrap-backend-$playVersion" % hmrcBootstrapVersion,
     hmrc      %% s"domain-$playVersion"            % "9.0.0",
-    hmrc      %% s"play-hal-$playVersion"          % "4.0.0",
+    hmrc      %% s"play-hal-$playVersion"          % "4.0.0", // for scala 3
     hmrcMongo %% s"hmrc-mongo-$playVersion"        % hmrcMongoVersion
   )
 
   def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
     hmrc                   %% s"bootstrap-test-$playVersion" % hmrcBootstrapVersion % scope,
-    "org.mockito"          %% "mockito-scala"                % "1.17.37"            % scope,
+    //"org.mockito"          %% "mockito-scala"                % "1.17.37"            % scope,
+   // "org.scalatestplus"    %% "mockito-4-11"                 % "3.2.17.0"           %scope,
     "org.scalatestplus"    %% "scalacheck-1-17"              % "3.2.18.0"           % scope,
-    "org.scalaj"           %% "scalaj-http"                  % "2.4.2"              % scope,
+    "com.codacy"           %% "scalaj-http"                  % "2.5.0"              % scope,
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,10 +16,8 @@ object AppDependencies {
   )
 
   def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
-    hmrc %% s"bootstrap-test-$playVersion" % hmrcBootstrapVersion % scope,
-    // "org.mockito"          %% "mockito-scala"                % "1.17.37"            % scope,
-    // "org.scalatestplus"    %% "mockito-4-11"                 % "3.2.17.0"           %scope,
-    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.18.0" % scope,
-    "com.codacy"        %% "scalaj-http"     % "2.5.0"    % scope
+    hmrc                %% s"bootstrap-test-$playVersion" % hmrcBootstrapVersion % scope,
+    "org.scalatestplus" %% "scalacheck-1-17"              % "3.2.18.0"           % scope,
+    "com.codacy"        %% "scalaj-http"                  % "2.5.0"              % scope
   )
 }

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -9,7 +9,8 @@ object CodeCoverageSettings {
     ".*BuildInfo.",
     "uk.gov.hmrc.BuildInfo",
     ".*Routes",
-    ".*RoutesPrefix*"
+    ".*RoutesPrefix*",
+    "uk.gov.hmrc.individualsmatchingapi.audit.models.*"
   )
 
   val settings: Seq[Setting[?]] = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,11 @@
 resolvers += Resolver.typesafeRepo("releases")
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
-  Resolver.ivyStylePatterns)
+  Resolver.ivyStylePatterns
+)
 
-addSbtPlugin("uk.gov.hmrc"        %% "sbt-auto-build"     % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"        %% "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework"  %% "sbt-plugin"         % "3.0.7")
-addSbtPlugin("org.scalameta"      %% "sbt-scalafmt"       % "2.5.2")
-addSbtPlugin("org.scoverage"      %% "sbt-scoverage"      % "2.3.0")
+addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"     % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"       %% "sbt-distributables" % "2.6.0")
+addSbtPlugin("org.playframework" %% "sbt-plugin"         % "3.0.7")
+addSbtPlugin("org.scalameta"     %% "sbt-scalafmt"       % "2.5.2")
+addSbtPlugin("org.scoverage"     %% "sbt-scoverage"      % "2.3.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns)
 
 addSbtPlugin("uk.gov.hmrc"        %% "sbt-auto-build"     % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"        %% "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework"  %% "sbt-plugin"         % "3.0.3")
+addSbtPlugin("uk.gov.hmrc"        %% "sbt-distributables" % "2.6.0")
+addSbtPlugin("org.playframework"  %% "sbt-plugin"         % "3.0.7")
 addSbtPlugin("org.scalameta"      %% "sbt-scalafmt"       % "2.5.2")
-addSbtPlugin("org.scoverage"      %% "sbt-scoverage"      % "2.0.10")
+addSbtPlugin("org.scoverage"      %% "sbt-scoverage"      % "2.3.0")

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
@@ -18,7 +18,7 @@ package component.uk.gov.hmrc.individualsmatchingapi.controllers
 
 import component.uk.gov.hmrc.individualsmatchingapi.stubs.BaseSpec
 import play.api.libs.json.Json
-import play.api.test.Helpers.{await, _}
+import play.api.test.Helpers.*
 import scalaj.http.Http
 import uk.gov.hmrc.domain.Nino
 

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
@@ -17,18 +17,18 @@
 package component.uk.gov.hmrc.individualsmatchingapi.controllers.v1
 
 import component.uk.gov.hmrc.individualsmatchingapi.stubs.{AuthStub, BaseSpec, CitizenDetailsStub, MatchingStub}
-import java.time.LocalDate
 import org.mongodb.scala.model.Filters
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.libs.json.Json
 import play.api.libs.json.Json.parse
 import play.api.test.Helpers.{BAD_REQUEST, NOT_FOUND}
 import scalaj.http.{Http, HttpResponse}
-import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters._
+import uk.gov.hmrc.individualsmatchingapi.domain.*
+import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.*
 import uk.gov.hmrc.individualsmatchingapi.domain.SandboxData.sandboxMatchId
-import uk.gov.hmrc.individualsmatchingapi.domain._
 import uk.gov.hmrc.mongo.play.json.Codecs.toBson
 
+import java.time.LocalDate
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationDouble
 

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
@@ -17,17 +17,17 @@
 package component.uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
 import component.uk.gov.hmrc.individualsmatchingapi.stubs.{AuthStub, BaseSpec, CitizenDetailsStub, MatchingStub}
-import java.time.LocalDate
 import org.mongodb.scala.model.Filters
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.libs.json.Json
 import play.api.libs.json.Json.parse
 import play.api.test.Helpers.{BAD_REQUEST, NOT_FOUND}
 import scalaj.http.{Http, HttpResponse}
-import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters._
-import uk.gov.hmrc.individualsmatchingapi.domain._
+import uk.gov.hmrc.individualsmatchingapi.domain.*
+import uk.gov.hmrc.individualsmatchingapi.domain.JsonFormatters.*
 import uk.gov.hmrc.mongo.play.json.Codecs.toBson
 
+import java.time.LocalDate
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationDouble
 

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/stubs/AuthStub.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/stubs/AuthStub.scala
@@ -16,7 +16,7 @@
 
 package component.uk.gov.hmrc.individualsmatchingapi.stubs
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.HeaderNames.AUTHORIZATION
 import play.api.http.{HeaderNames, Status}

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/stubs/MatchingStub.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/stubs/MatchingStub.scala
@@ -16,7 +16,7 @@
 
 package component.uk.gov.hmrc.individualsmatchingapi.stubs
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import uk.gov.hmrc.individualsmatchingapi.domain.{CitizenDetails, CitizenMatchingRequest}
 

--- a/test/it/uk/gov/hmrc/individualsmatchingapi/repository/NinoMatchRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsmatchingapi/repository/NinoMatchRepositorySpec.scala
@@ -16,6 +16,7 @@
 
 package it.uk.gov.hmrc.individualsmatchingapi.repository
 
+import org.mongodb.scala.ObservableFuture
 import org.mongodb.scala.model.IndexModel
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
@@ -38,12 +39,12 @@ class NinoMatchRepositorySpec extends SpecBase with Matchers with BeforeAndAfter
   protected val mongoUri: String =
     s"mongodb://127.0.0.1:27017/$databaseName?heartbeatFrequencyMS=1000&rm.failover=default"
 
-  override lazy val fakeApplication: Application = new GuiceApplicationBuilder()
+  override def fakeApplication(): Application = new GuiceApplicationBuilder()
     .configure(Configuration("mongodb.uri" -> mongoUri, "mongodb.ninoMatchTtlInSeconds" -> ninoMatchTtl))
     .build()
 
   val nino: Nino = Nino("AB123456A")
-  val ninoMatchRepository: NinoMatchRepository = fakeApplication.injector.instanceOf[NinoMatchRepository]
+  val ninoMatchRepository: NinoMatchRepository = fakeApplication().injector.instanceOf[NinoMatchRepository]
 
   override def beforeEach(): Unit = {
     ninoMatchRepository.collection.drop()

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -9,5 +9,5 @@
             </pattern>
         </encoder>
     </appender>
-    <root level="OFF" />
+    <root level="OFF"/>
 </configuration>

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/audit/AuditHelperSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/audit/AuditHelperSpec.scala
@@ -16,10 +16,11 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.audit
 
-import org.mockito.ArgumentMatchersSugar.{*, eqTo}
-import org.mockito.Mockito.{times, verify}
-import org.mockito.{ArgumentCaptor, IdiomaticMockito, Mockito}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{reset, times, verify}
+import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -31,7 +32,7 @@ import unit.uk.gov.hmrc.individualsmatchingapi.support.SpecBase
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AuditHelperSpec extends SpecBase with Matchers with IdiomaticMockito {
+class AuditHelperSpec extends SpecBase with Matchers with MockitoSugar {
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   val correlationId = "test"
@@ -56,7 +57,7 @@ class AuditHelperSpec extends SpecBase with Matchers with IdiomaticMockito {
       auditHelper.auditAuthScopes(matchId, scopes, request)
 
       verify(auditConnector, times(1))
-        .sendExplicitAudit(eqTo("AuthScopesAuditEvent"), captor.capture())(*, *, *)
+        .sendExplicitAudit(eqTo("AuthScopesAuditEvent"), captor.capture())(any, any, any)
 
       val capturedEvent = captor.getValue
       capturedEvent.apiVersion shouldEqual "2.0"
@@ -75,7 +76,7 @@ class AuditHelperSpec extends SpecBase with Matchers with IdiomaticMockito {
       auditHelper.auditApiResponse(correlationId, matchId, scopes, request, endpoint, response)
 
       verify(auditConnector, times(1))
-        .sendExplicitAudit(eqTo("ApiResponseEvent"), captor.capture())(*, *, *)
+        .sendExplicitAudit(eqTo("ApiResponseEvent"), captor.capture())(any, any, any)
 
       val capturedEvent = captor.getValue
       capturedEvent.matchId shouldEqual matchId
@@ -97,7 +98,7 @@ class AuditHelperSpec extends SpecBase with Matchers with IdiomaticMockito {
 
       auditHelper.auditApiFailure(Some(correlationId), matchId, request, "/test", msg)
 
-      verify(auditConnector, times(1)).sendExplicitAudit(eqTo("ApiFailureEvent"), captor.capture())(*, *, *)
+      verify(auditConnector, times(1)).sendExplicitAudit(eqTo("ApiFailureEvent"), captor.capture())(any, any, any)
 
       val capturedEvent = captor.getValue
       capturedEvent.matchId shouldEqual matchId

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/connectors/CitizenDetailsConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/connectors/CitizenDetailsConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/connectors/MatchingConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/connectors/MatchingConnectorSpec.scala
@@ -16,14 +16,14 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.test.WireMockSupport
 import uk.gov.hmrc.individualsmatchingapi.connectors.MatchingConnector
-import uk.gov.hmrc.individualsmatchingapi.domain._
+import uk.gov.hmrc.individualsmatchingapi.domain.*
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import unit.uk.gov.hmrc.individualsmatchingapi.support.SpecBase
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/DocumentationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/DocumentationControllerSpec.scala
@@ -18,8 +18,9 @@ package unit.uk.gov.hmrc.individualsmatchingapi.controllers
 
 import controllers.Assets
 import org.apache.pekko.stream.Materializer
-import org.mockito.IdiomaticMockito
+import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 import play.api.http.HttpErrorHandler
 import play.api.libs.json.JsValue
@@ -33,7 +34,7 @@ import java.nio.file.{Files, Paths}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class DocumentationControllerSpec extends SpecBase with Matchers with IdiomaticMockito {
+class DocumentationControllerSpec extends SpecBase with Matchers with MockitoSugar {
   implicit lazy val materializer: Materializer = app.materializer
 
   trait Setup {
@@ -49,17 +50,17 @@ class DocumentationControllerSpec extends SpecBase with Matchers with IdiomaticM
     val underTest =
       new DocumentationController(controllerComponents, assets, configuration)
 
-    configuration.getOptional[Seq[String]]("api.access.version-P1.0.whitelistedApplicationIds").returns(None)
-    configuration.getOptional[Seq[String]]("api.access.version-1.0.whitelistedApplicationIds").returns(None)
-    configuration.getOptional[String]("api.access.version-1.0.accessType").returns(None)
-    configuration.getOptional[Seq[String]]("api.access.version-2.0.whitelistedApplicationIds").returns(None)
-    configuration.getOptional[String]("api.access.version-2.0.status").returns(None)
-    configuration.getOptional[Boolean]("api.access.version-2.0.endpointsEnabled").returns(None)
+    when(configuration.getOptional[Seq[String]]("api.access.version-P1.0.whitelistedApplicationIds")).thenReturn(None)
+    when(configuration.getOptional[Seq[String]]("api.access.version-1.0.whitelistedApplicationIds")).thenReturn(None)
+    when(configuration.getOptional[String]("api.access.version-1.0.accessType")).thenReturn(None)
+    when(configuration.getOptional[Seq[String]]("api.access.version-2.0.whitelistedApplicationIds")).thenReturn(None)
+    when(configuration.getOptional[String]("api.access.version-2.0.status")).thenReturn(None)
+    when(configuration.getOptional[Boolean]("api.access.version-2.0.endpointsEnabled")).thenReturn(None)
   }
 
   "/api/definition" should {
     "return 1.0 as PRIVATE when api.access.version-1.0.accessType is not set" in new Setup {
-      configuration.getOptional[String]("api.access.version-1.0.accessType").returns(None)
+      when(configuration.getOptional[String]("api.access.version-1.0.accessType")).thenReturn(None)
 
       val result: Future[Result] = underTest.definition()(request)
 
@@ -68,7 +69,7 @@ class DocumentationControllerSpec extends SpecBase with Matchers with IdiomaticM
     }
 
     "return 1.0 as PRIVATE when api.access.version-1.0.accessType is set to PRIVATE" in new Setup {
-      configuration.getOptional[String]("api.access.version-1.0.accessType").returns(Some("PRIVATE"))
+      when(configuration.getOptional[String]("api.access.version-1.0.accessType")).thenReturn(Some("PRIVATE"))
 
       val result: Future[Result] = underTest.definition()(request)
 
@@ -77,7 +78,7 @@ class DocumentationControllerSpec extends SpecBase with Matchers with IdiomaticM
     }
 
     "return 1.0 as PUBLIC when api.access.version-1.0.accessType is set to PUBLIC" in new Setup {
-      configuration.getOptional[String]("api.access.version-1.0.accessType").returns(Some("PUBLIC"))
+      when(configuration.getOptional[String]("api.access.version-1.0.accessType")).thenReturn(Some("PUBLIC"))
 
       val result: Future[Result] = underTest.definition()(request)
 
@@ -94,7 +95,7 @@ class DocumentationControllerSpec extends SpecBase with Matchers with IdiomaticM
     }
 
     "return 2.0 as ALPHA when api.access.version-2.0.status is set" in new Setup {
-      configuration.getOptional[String]("api.access.version-2.0.status").returns(Some("ALPHA"))
+      when(configuration.getOptional[String]("api.access.version-2.0.status")).thenReturn(Some("ALPHA"))
 
       val result: Future[Result] = underTest.definition()(request)
 
@@ -112,7 +113,7 @@ class DocumentationControllerSpec extends SpecBase with Matchers with IdiomaticM
 
     "return endpoints enabled false when api.access.version-2.0.endpointsEnabled is set" in new Setup {
 
-      configuration.getOptional[Boolean]("api.access.version-2.0.endpointsEnabled").returns(Some(false))
+      when(configuration.getOptional[Boolean]("api.access.version-2.0.endpointsEnabled")).thenReturn(Some(false))
 
       val result: Future[Result] = underTest.definition()(request)
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
@@ -18,8 +18,9 @@ package unit.uk.gov.hmrc.individualsmatchingapi.controllers
 
 import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
-import org.mockito.IdiomaticMockito
+import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, Result}
@@ -36,7 +37,7 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class MatchedCitizenControllerSpec extends SpecBase with Matchers with IdiomaticMockito {
+class MatchedCitizenControllerSpec extends SpecBase with Matchers with MockitoSugar {
   implicit lazy val materializer: Materializer = app.materializer
 
   trait Setup {
@@ -56,9 +57,11 @@ class MatchedCitizenControllerSpec extends SpecBase with Matchers with Idiomatic
   "matched citizen controller" should {
 
     "return 200 (OK) for a valid matchId" in new Setup {
-      mockCitizenMatchingService
-        .fetchMatchedCitizenRecord(matchId)(any[HeaderCarrier])
-        .returns(Future.successful(matchedCitizenRecord))
+      when(
+        mockCitizenMatchingService
+          .fetchMatchedCitizenRecord(matchId)(any[HeaderCarrier])
+      )
+        .thenReturn(Future.successful(matchedCitizenRecord))
 
       val result: Future[Result] = matchedCitizenController.matchedCitizen(matchId.toString)(fakeRequest)
 
@@ -69,9 +72,10 @@ class MatchedCitizenControllerSpec extends SpecBase with Matchers with Idiomatic
     }
 
     "return 404 (Not Found) for an invalid matchId" in new Setup {
-      mockCitizenMatchingService
-        .fetchMatchedCitizenRecord(matchId)(any[HeaderCarrier])
-        .returns(Future.failed(new MatchNotFoundException))
+      when(
+        mockCitizenMatchingService
+          .fetchMatchedCitizenRecord(matchId)(any[HeaderCarrier])
+      ).thenReturn(Future.failed(new MatchNotFoundException))
 
       val result: Future[Result] = matchedCitizenController.matchedCitizen(matchId.toString)(fakeRequest)
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers
 
 import org.apache.pekko.stream.Materializer
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -59,7 +59,7 @@ class MatchedCitizenControllerSpec extends SpecBase with Matchers with MockitoSu
     "return 200 (OK) for a valid matchId" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchMatchedCitizenRecord(matchId)(any[HeaderCarrier])
+          .fetchMatchedCitizenRecord(eqTo(matchId))(any[HeaderCarrier])
       )
         .thenReturn(Future.successful(matchedCitizenRecord))
 
@@ -74,7 +74,7 @@ class MatchedCitizenControllerSpec extends SpecBase with Matchers with MockitoSu
     "return 404 (Not Found) for an invalid matchId" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchMatchedCitizenRecord(matchId)(any[HeaderCarrier])
+          .fetchMatchedCitizenRecord(eqTo(matchId))(any[HeaderCarrier])
       ).thenReturn(Future.failed(new MatchNotFoundException))
 
       val result: Future[Result] = matchedCitizenController.matchedCitizen(matchId.toString)(fakeRequest)

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/MatchedCitizenControllerSpec.scala
@@ -21,7 +21,7 @@ import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.libs.json.Json
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, Result}
 import play.api.test.FakeRequest

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
@@ -24,13 +24,13 @@ import play.api.libs.json.Json.parse
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{contentAsJson, _}
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
 import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment, InsufficientEnrolments}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsmatchingapi.controllers.v1.{LivePrivilegedCitizenMatchingController, SandboxPrivilegedCitizenMatchingController}
+import uk.gov.hmrc.individualsmatchingapi.domain.*
 import uk.gov.hmrc.individualsmatchingapi.domain.SandboxData.sandboxMatchId
-import uk.gov.hmrc.individualsmatchingapi.domain._
 import uk.gov.hmrc.individualsmatchingapi.services.{LiveCitizenMatchingService, SandboxCitizenMatchingService}
 import unit.uk.gov.hmrc.individualsmatchingapi.support.SpecBase
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers.v1
 
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -64,7 +64,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       controllerComponents
     )
 
-    when(mockAuthConnector.authorise(any(), EmptyRetrieval)(any(), any())).thenReturn(successful(()))
+    when(mockAuthConnector.authorise(any(), eqTo(EmptyRetrieval))(any(), any())).thenReturn(successful(()))
   }
 
   "live matching citizen controller" should {
@@ -293,7 +293,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
 
       when(
         mockAuthConnector
-          .authorise(Enrolment("read:individuals-matching"), EmptyRetrieval)(any(), any())
+          .authorise(eqTo(Enrolment("read:individuals-matching")), eqTo(EmptyRetrieval))(any(), any())
       ).thenReturn(failed(InsufficientEnrolments()))
 
       intercept[InsufficientEnrolments] {

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedCitizenMatchingControllerSpec.scala
@@ -17,8 +17,9 @@
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers.v1
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.IdiomaticMockito
+import org.mockito.Mockito.{verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json.parse
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, Result}
@@ -39,7 +40,7 @@ import scala.concurrent.Future
 import scala.concurrent.Future.{failed, successful}
 import scala.util.Random
 
-class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers with IdiomaticMockito {
+class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers with MockitoSugar {
 
   // noinspection ForwardReference
   trait Setup {
@@ -63,7 +64,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       controllerComponents
     )
 
-    mockAuthConnector.authorise(any(), EmptyRetrieval)(any(), any()).returns(successful(()))
+    when(mockAuthConnector.authorise(any(), EmptyRetrieval)(any(), any())).thenReturn(successful(()))
   }
 
   "live matching citizen controller" should {
@@ -71,9 +72,10 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
     val matchId = UUID.randomUUID()
 
     "return 200 (Ok) for a matched citizen" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.successful(matchId))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(matchId))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(fakeRequest.withBody(parse(matchingRequest())))
 
@@ -96,7 +98,9 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
     }
 
     "return 200 Ok when matching a user with a '.' in their name" in new Setup {
-      mockLiveCitizenMatchingService.matchCitizen(any())(any()).returns(Future.successful(matchId))
+      when(
+        mockLiveCitizenMatchingService.matchCitizen(any())(any())
+      ).thenReturn(Future.successful(matchId))
 
       val payload: JsObject = Json.obj(
         "firstName"   -> "Mr.",
@@ -110,9 +114,10 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
     }
 
     "return 403 (Forbidden) for a citizen not found" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.failed(new CitizenNotFoundException))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.failed(new CitizenNotFoundException))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(fakeRequest.withBody(parse(matchingRequest())))
 
@@ -124,9 +129,10 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
     }
 
     "return 403 (Forbidden) when a matching exception is thrown" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.failed(new MatchingException))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.failed(new MatchingException))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(fakeRequest.withBody(parse(matchingRequest())))
 
@@ -138,9 +144,10 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
     }
 
     "return 403 (Forbidden) when an invalid nino exception is thrown" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.failed(new InvalidNinoException()))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.failed(new InvalidNinoException()))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(fakeRequest.withBody(parse(matchingRequest())))
 
@@ -284,15 +291,15 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       val requestBody: JsValue =
         parse("""{"firstName":"Amanda","lastName":"Joseph","nino":"NA000799C","dateOfBirth":"2020-01-32"}""")
 
-      mockAuthConnector
-        .authorise(Enrolment("read:individuals-matching"), EmptyRetrieval)(any(), any())
-        .returns(failed(InsufficientEnrolments()))
+      when(
+        mockAuthConnector
+          .authorise(Enrolment("read:individuals-matching"), EmptyRetrieval)(any(), any())
+      ).thenReturn(failed(InsufficientEnrolments()))
 
       intercept[InsufficientEnrolments] {
         await(liveController.matchCitizen()(fakeRequest.withBody(requestBody)))
       }
-
-      mockLiveCitizenMatchingService wasNever called
+      verifyNoInteractions(mockLiveCitizenMatchingService)
     }
   }
 
@@ -393,7 +400,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
         sandboxController.matchCitizen()(fakeRequest.withBody(parse(matchingRequest())))
 
       status(eventualResult) mustBe OK
-      mockAuthConnector wasNever called
+      verifyNoInteractions(mockAuthConnector)
     }
   }
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedIndividualsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedIndividualsControllerSpec.scala
@@ -20,11 +20,10 @@ import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.mvc.{ControllerComponents, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{contentAsJson, _}
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
 import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment, InsufficientEnrolments}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedIndividualsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v1/PrivilegedIndividualsControllerSpec.scala
@@ -16,8 +16,8 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers.v1
 
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{doReturn, verifyNoInteractions, when}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status.OK
@@ -51,21 +51,21 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
     val controllerComponents: ControllerComponents =
       app.injector.instanceOf[ControllerComponents]
 
-    val liveController =
+    val liveController: LivePrivilegedIndividualsController =
       new LivePrivilegedIndividualsController(mockCitizenMatchingService, mockAuthConnector, controllerComponents)
-    val sandboxController = new SandboxPrivilegedIndividualsController(
+    val sandboxController: SandboxPrivilegedIndividualsController = new SandboxPrivilegedIndividualsController(
       new SandboxCitizenMatchingService(),
       mockAuthConnector,
       controllerComponents
     )
-    doReturn(successful(())).when(mockAuthConnector.authorise(any(), EmptyRetrieval)(any(), any()))
+    when(mockAuthConnector.authorise(any(), eqTo(EmptyRetrieval))(any(), any())).thenReturn(successful(()))
   }
 
   "The live matched individual function" should {
     "respond with http 404 (not found) for an invalid matchId" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+          .fetchCitizenDetailsByMatchId(eqTo(uuid))(any[HeaderCarrier])
       )
         .thenReturn(failed(new MatchNotFoundException))
 
@@ -80,7 +80,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
     "respond with http 200 (ok) when a nino match is successful and citizen details exist" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+          .fetchCitizenDetailsByMatchId(eqTo(uuid))(any[HeaderCarrier])
       )
         .thenReturn(successful(citizenDetails("Joe", "Bloggs", "AB123456C", "1969-01-15")))
       val eventualResult: Future[Result] =
@@ -93,7 +93,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
 
       when(
         mockAuthConnector
-          .authorise(Enrolment("read:individuals-matching"), EmptyRetrieval)(any(), any())
+          .authorise(eqTo(Enrolment("read:individuals-matching")), eqTo(EmptyRetrieval))(any(), any())
       )
         .thenReturn(failed(InsufficientEnrolments()))
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
@@ -22,15 +22,15 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json.parse
 import play.api.libs.json.{JsObject, JsValue, Json}
-import play.api.mvc._
+import play.api.mvc.*
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{contentAsJson, _}
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment, Enrolments, InsufficientEnrolments}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsmatchingapi.audit.AuditHelper
 import uk.gov.hmrc.individualsmatchingapi.controllers.v2.PrivilegedCitizenMatchingController
-import uk.gov.hmrc.individualsmatchingapi.domain._
+import uk.gov.hmrc.individualsmatchingapi.domain.*
 import uk.gov.hmrc.individualsmatchingapi.services.{LiveCitizenMatchingService, ScopesService}
 import unit.uk.gov.hmrc.individualsmatchingapi.support.SpecBase
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
@@ -17,9 +17,9 @@
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.IdiomaticMockito
-import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.{verify, verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json.parse
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc._
@@ -40,7 +40,7 @@ import scala.concurrent.Future
 import scala.concurrent.Future.failed
 import scala.util.Random
 
-class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers with IdiomaticMockito {
+class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers with MockitoSugar {
   trait Setup extends ScopesConfigHelper {
     val sampleCorrelationId = "188e9400-b636-4a3b-80ba-230a8c72b92a"
 
@@ -63,9 +63,11 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       mockAuditHelper
     )
 
-    mockAuthConnector
-      .authorise(any(), Retrievals.allEnrolments)(any(), any())
-      .returns(Future.successful(Enrolments(Set(Enrolment("test-scope")))))
+    when(
+      mockAuthConnector
+        .authorise(any(), Retrievals.allEnrolments)(any(), any())
+    ).thenReturn(Future.successful(Enrolments(Set(Enrolment("test-scope")))))
+
   }
 
   "live matching citizen controller" should {
@@ -73,9 +75,10 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
     val matchId = UUID.randomUUID()
 
     "return 200 (Ok) for a matched citizen" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.successful(matchId))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(matchId))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(
         fakeRequest.withBody(parse(matchingRequest())).withHeaders(("CorrelationId", sampleCorrelationId))
@@ -96,13 +99,12 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
                }
              }"""
       )
-
-      mockAuditHelper.auditApiResponse(any(), any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiResponse(any(), any(), any(), any(), any(), any())(any())
     }
 
     "return 200 Ok when matching a user with a '.' in their name" in new Setup {
 
-      mockLiveCitizenMatchingService.matchCitizen(any())(any()).returns(Future.successful(matchId))
+      when(mockLiveCitizenMatchingService.matchCitizen(any())(any())).thenReturn(Future.successful(matchId))
 
       val payload: JsObject = Json.obj(
         "firstName"   -> "Mr.",
@@ -114,13 +116,14 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       val res: Future[Result] =
         liveController.matchCitizen()(fakeRequest.withBody(payload).withHeaders(("CorrelationId", sampleCorrelationId)))
       status(res) mustBe OK
-      mockAuditHelper.auditApiResponse(any(), any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiResponse(any(), any(), any(), any(), any(), any())(any())
     }
 
     "return 404 (Not Found) for a citizen not found" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.failed(new CitizenNotFoundException))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.failed(new CitizenNotFoundException))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(
         fakeRequest.withBody(parse(matchingRequest())).withHeaders(("CorrelationId", sampleCorrelationId))
@@ -132,13 +135,14 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
         "message" -> "There is no match for the information provided"
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 403 (Forbidden) when a matching exception is thrown" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.failed(new MatchingException))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.failed(new MatchingException))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(
         fakeRequest.withBody(parse(matchingRequest())).withHeaders(("CorrelationId", sampleCorrelationId))
@@ -150,13 +154,14 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
         "message" -> "There is no match for the information provided"
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 404 (Not Found) when an invalid nino exception is thrown" in new Setup {
-      mockLiveCitizenMatchingService
-        .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
-        .returns(Future.failed(new InvalidNinoException()))
+      when(
+        mockLiveCitizenMatchingService
+          .matchCitizen(any[CitizenMatchingRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.failed(new InvalidNinoException()))
 
       val eventualResult: Future[Result] = liveController.matchCitizen()(
         fakeRequest.withBody(parse(matchingRequest())).withHeaders(("CorrelationId", sampleCorrelationId))
@@ -168,7 +173,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
         "message" -> "There is no match for the information provided"
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 400 (BadRequest) for an invalid dateOfBirth" in new Setup {
@@ -185,7 +190,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
         "message" -> "dateOfBirth: invalid date format"
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
 
       requestBody = parse("""{"firstName":"Amanda","lastName":"Joseph","nino":"NA000799C","dateOfBirth":"20200131"}""")
       eventualResult = liveController.matchCitizen()(
@@ -213,7 +218,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
         "message" -> "Malformed nino submitted"
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 400 Bad Request when the first name is empty" in new Setup {
@@ -232,7 +237,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       status(res) mustBe BAD_REQUEST
       contentAsJson(res) mustBe Json.obj("code" -> "INVALID_REQUEST", "message" -> "firstName is required")
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 400 Bad Request when the last name is empty" in new Setup {
@@ -250,7 +255,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       status(res) mustBe BAD_REQUEST
       contentAsJson(res) mustBe Json.obj("code" -> "INVALID_REQUEST", "message" -> "lastName is required")
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 400 Bad Request when the first name is greater than 35 characters" in new Setup {
@@ -270,7 +275,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       contentAsJson(res) mustBe Json
         .obj("code" -> "INVALID_REQUEST", "message" -> "firstName must be no more than 35 characters")
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 400 Bad Request when the last name is greater than 35 characters" in new Setup {
@@ -290,7 +295,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       contentAsJson(res) mustBe Json
         .obj("code" -> "INVALID_REQUEST", "message" -> "lastName must be no more than 35 characters")
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 400 Bad Request when the first name contains invalid characters" in new Setup {
@@ -309,7 +314,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       contentAsJson(res) mustBe Json
         .obj("code" -> "INVALID_REQUEST", "message" -> "firstName contains invalid characters")
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "return 400 Bad Request when the last name contains invalid characters" in new Setup {
@@ -328,16 +333,17 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
       contentAsJson(res) mustBe Json
         .obj("code" -> "INVALID_REQUEST", "message" -> "lastName contains invalid characters")
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "fail with UnauthorizedException when the bearer token does not have enrolment read:individuals-matching" in new Setup {
       val requestBody: JsValue =
         parse("""{"firstName":"Amanda","lastName":"Joseph","nino":"NA000799C","dateOfBirth":"2020-01-32"}""")
 
-      mockAuthConnector
-        .authorise(any(), Retrievals.allEnrolments)(any(), any())
-        .returns(failed(InsufficientEnrolments()))
+      when(
+        mockAuthConnector
+          .authorise(any(), Retrievals.allEnrolments)(any(), any())
+      ).thenReturn(failed(InsufficientEnrolments()))
 
       val res: Future[Result] = liveController.matchCitizen()(
         fakeRequest.withBody(requestBody).withHeaders(("CorrelationId", sampleCorrelationId))
@@ -347,7 +353,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
         .obj("code" -> "UNAUTHORIZED", "message" -> "Insufficient Enrolments")
       verifyNoInteractions(mockLiveCitizenMatchingService)
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
   }
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -65,7 +65,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
 
     when(
       mockAuthConnector
-        .authorise(any(), Retrievals.allEnrolments)(any(), any())
+        .authorise(any(), eqTo(Retrievals.allEnrolments))(any(), any())
     ).thenReturn(Future.successful(Enrolments(Set(Enrolment("test-scope")))))
 
   }
@@ -342,7 +342,7 @@ class PrivilegedCitizenMatchingControllerSpec extends SpecBase with Matchers wit
 
       when(
         mockAuthConnector
-          .authorise(any(), Retrievals.allEnrolments)(any(), any())
+          .authorise(any(), eqTo(Retrievals.allEnrolments))(any(), any())
       ).thenReturn(failed(InsufficientEnrolments()))
 
       val res: Future[Result] = liveController.matchCitizen()(

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
@@ -17,9 +17,9 @@
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.IdiomaticMockito
-import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.{verify, verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.mvc.{ControllerComponents, Result}
@@ -40,7 +40,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.Future.{failed, successful}
 
-class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with IdiomaticMockito with Individuals {
+class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with MockitoSugar with Individuals {
   val uuid: UUID = UUID.randomUUID()
   val sampleCorrelationId = "188e9400-b636-4a3b-80ba-230a8c72b92a"
 
@@ -64,16 +64,20 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Id
       controllerComponents
     )
 
-    mockAuthConnector
-      .authorise(any(), Retrievals.allEnrolments)(any(), any())
-      .returns(Future.successful(Enrolments(Set(Enrolment("test-scope")))))
+    when(
+      mockAuthConnector
+        .authorise(any(), Retrievals.allEnrolments)(any(), any())
+    )
+      .thenReturn(Future.successful(Enrolments(Set(Enrolment("test-scope")))))
   }
 
   "The live matched individual function" should {
     "respond with http 404 (not found) for an invalid matchId" in new Setup {
-      mockCitizenMatchingService
-        .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
-        .returns(failed(new MatchNotFoundException))
+      when(
+        mockCitizenMatchingService
+          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+      )
+        .thenReturn(failed(new MatchNotFoundException))
 
       val eventualResult: Future[Result] = liveController
         .matchedIndividual(uuid.toString)
@@ -84,13 +88,15 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Id
         """{"code":"NOT_FOUND","message":"The resource can not be found"}"""
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "respond with http 200 (ok) when a nino match is successful and citizen details exist" in new Setup {
-      mockCitizenMatchingService
-        .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
-        .returns(successful(citizenDetails("Joe", "Bloggs", "AB123456C", "1969-01-15")))
+      when(
+        mockCitizenMatchingService
+          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+      )
+        .thenReturn(successful(citizenDetails("Joe", "Bloggs", "AB123456C", "1969-01-15")))
       val eventualResult: Future[Result] =
         liveController
           .matchedIndividual(uuid.toString)
@@ -98,18 +104,22 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Id
       status(eventualResult) mustBe OK
       contentAsJson(eventualResult) mustBe Json.parse(response(uuid, "Joe", "Bloggs", "AB123456C", "1969-01-15"))
 
-      mockAuditHelper.auditApiResponse(any(), any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiResponse(any(), any(), any(), any(), any(), any())(any())
     }
 
     "fail with AuthorizedException when the bearer token does not have a valid enrolment" in new Setup {
 
-      mockAuthConnector
-        .authorise(any(), Retrievals.allEnrolments)(any(), any())
-        .returns(failed(InsufficientEnrolments()))
+      when(
+        mockAuthConnector
+          .authorise(any(), Retrievals.allEnrolments)(any(), any())
+      )
+        .thenReturn(failed(InsufficientEnrolments()))
 
-      mockCitizenMatchingService
-        .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
-        .returns(failed(new MatchNotFoundException))
+      when(
+        mockCitizenMatchingService
+          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+      )
+        .thenReturn(failed(new MatchNotFoundException))
 
       val res: Future[Result] = liveController
         .matchedIndividual(uuid.toString)
@@ -119,13 +129,15 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Id
       contentAsJson(res) mustBe Json.parse("""{"code":"UNAUTHORIZED","message":"Insufficient Enrolments"}""")
 
       verifyNoInteractions(mockCitizenMatchingService)
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "respond with http 400 (Bad Request) for a malformed CorrelationId" in new Setup {
-      mockCitizenMatchingService
-        .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
-        .returns(failed(new MatchNotFoundException))
+      when(
+        mockCitizenMatchingService
+          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+      )
+        .thenReturn(failed(new MatchNotFoundException))
 
       val res: Future[Result] = liveController
         .matchedIndividual(uuid.toString)
@@ -141,13 +153,15 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Id
           |""".stripMargin
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
 
     "respond with http 400 (Bad Request) for a missing CorrelationId" in new Setup {
-      mockCitizenMatchingService
-        .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
-        .returns(failed(new MatchNotFoundException))
+      when(
+        mockCitizenMatchingService
+          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+      )
+        .thenReturn(failed(new MatchNotFoundException))
 
       val res: Future[Result] = liveController.matchedIndividual(uuid.toString).apply(FakeRequest())
 
@@ -161,7 +175,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Id
           |""".stripMargin
       )
 
-      mockAuditHelper.auditApiFailure(any(), any(), any(), any(), any())(any()) was called
+      verify(mockAuditHelper).auditApiFailure(any(), any(), any(), any(), any())(any())
     }
   }
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
@@ -20,11 +20,10 @@ import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.mvc.{ControllerComponents, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{contentAsJson, _}
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment, Enrolments, InsufficientEnrolments}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.controllers.v2
 
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, verifyNoInteractions, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -66,7 +66,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
 
     when(
       mockAuthConnector
-        .authorise(any(), Retrievals.allEnrolments)(any(), any())
+        .authorise(any(), eqTo(Retrievals.allEnrolments))(any(), any())
     )
       .thenReturn(Future.successful(Enrolments(Set(Enrolment("test-scope")))))
   }
@@ -75,7 +75,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
     "respond with http 404 (not found) for an invalid matchId" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+          .fetchCitizenDetailsByMatchId(eqTo(uuid))(any[HeaderCarrier])
       )
         .thenReturn(failed(new MatchNotFoundException))
 
@@ -94,7 +94,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
     "respond with http 200 (ok) when a nino match is successful and citizen details exist" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+          .fetchCitizenDetailsByMatchId(eqTo(uuid))(any[HeaderCarrier])
       )
         .thenReturn(successful(citizenDetails("Joe", "Bloggs", "AB123456C", "1969-01-15")))
       val eventualResult: Future[Result] =
@@ -111,13 +111,13 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
 
       when(
         mockAuthConnector
-          .authorise(any(), Retrievals.allEnrolments)(any(), any())
+          .authorise(any(), eqTo(Retrievals.allEnrolments))(any(), any())
       )
         .thenReturn(failed(InsufficientEnrolments()))
 
       when(
         mockCitizenMatchingService
-          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+          .fetchCitizenDetailsByMatchId(eqTo(uuid))(any[HeaderCarrier])
       )
         .thenReturn(failed(new MatchNotFoundException))
 
@@ -135,7 +135,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
     "respond with http 400 (Bad Request) for a malformed CorrelationId" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+          .fetchCitizenDetailsByMatchId(eqTo(uuid))(any[HeaderCarrier])
       )
         .thenReturn(failed(new MatchNotFoundException))
 
@@ -159,7 +159,7 @@ class PrivilegedIndividualsControllerSpec extends SpecBase with Matchers with Mo
     "respond with http 400 (Bad Request) for a missing CorrelationId" in new Setup {
       when(
         mockCitizenMatchingService
-          .fetchCitizenDetailsByMatchId(uuid)(any[HeaderCarrier])
+          .fetchCitizenDetailsByMatchId(eqTo(uuid))(any[HeaderCarrier])
       )
         .thenReturn(failed(new MatchNotFoundException))
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/play/RequestHeaderUtilsSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/play/RequestHeaderUtilsSpec.scala
@@ -19,7 +19,7 @@ package unit.uk.gov.hmrc.individualsmatchingapi.play
 import org.scalatest.matchers.should.Matchers
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{ACCEPT, GET}
-import uk.gov.hmrc.individualsmatchingapi.play.RequestHeaderUtils._
+import uk.gov.hmrc.individualsmatchingapi.play.RequestHeaderUtils.*
 import unit.uk.gov.hmrc.individualsmatchingapi.support.SpecBase
 
 class RequestHeaderUtilsSpec extends SpecBase with Matchers {

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingServiceSpec.scala
@@ -25,8 +25,8 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsmatchingapi.connectors.{CitizenDetailsConnector, MatchingConnector}
+import uk.gov.hmrc.individualsmatchingapi.domain.*
 import uk.gov.hmrc.individualsmatchingapi.domain.SandboxData.sandboxMatchId
-import uk.gov.hmrc.individualsmatchingapi.domain._
 import uk.gov.hmrc.individualsmatchingapi.repository.NinoMatchRepository
 import uk.gov.hmrc.individualsmatchingapi.services.{LiveCitizenMatchingService, SandboxCitizenMatchingService}
 import unit.uk.gov.hmrc.individualsmatchingapi.support.SpecBase

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/services/CitizenMatchingServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.services
 
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verifyNoInteractions, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -67,17 +67,17 @@ class CitizenMatchingServiceSpec extends SpecBase with Matchers with MockitoSuga
 
       when(
         mockCitizenDetailsConnector
-          .citizenDetails(ninoString)(any[HeaderCarrier])
+          .citizenDetails(eqTo(ninoString))(any[HeaderCarrier])
       ).thenReturn(Future.successful(details))
 
       when(
         mockMatchingConnector
-          .validateMatch(detailsMatchRequest)(any[HeaderCarrier])
+          .validateMatch(eqTo(detailsMatchRequest))(any[HeaderCarrier])
       ).thenReturn(Future.successful(()))
 
       when(
         mockNinoMatchRepository
-          .create(nino)
+          .create(eqTo(nino))
       ).thenReturn(Future.successful(ninoMatch))
 
       val result: UUID = await(liveService.matchCitizen(citizenMatchingRequest))
@@ -88,7 +88,7 @@ class CitizenMatchingServiceSpec extends SpecBase with Matchers with MockitoSuga
     "propagate exception when citizen details are not found" in new Setup {
       when(
         mockCitizenDetailsConnector
-          .citizenDetails(ninoString)(any[HeaderCarrier])
+          .citizenDetails(eqTo(ninoString))(any[HeaderCarrier])
       ).thenReturn(Future.failed(new CitizenNotFoundException))
 
       intercept[CitizenNotFoundException](await(liveService.matchCitizen(citizenMatchingRequest)))
@@ -98,7 +98,7 @@ class CitizenMatchingServiceSpec extends SpecBase with Matchers with MockitoSuga
     "propagate exception for an invalid nino" in new Setup {
       when(
         mockCitizenDetailsConnector
-          .citizenDetails(ninoString)(any[HeaderCarrier])
+          .citizenDetails(eqTo(ninoString))(any[HeaderCarrier])
       ).thenReturn(Future.failed(new InvalidNinoException))
 
       intercept[InvalidNinoException](await(liveService.matchCitizen(citizenMatchingRequest)))
@@ -107,12 +107,12 @@ class CitizenMatchingServiceSpec extends SpecBase with Matchers with MockitoSuga
     "propagate exception for a non-match" in new Setup {
       when(
         mockCitizenDetailsConnector
-          .citizenDetails(ninoString)(any[HeaderCarrier])
+          .citizenDetails(eqTo(ninoString))(any[HeaderCarrier])
       )
         .thenReturn(Future.successful(details))
       when(
         mockMatchingConnector
-          .validateMatch(detailsMatchRequest)(any[HeaderCarrier])
+          .validateMatch(eqTo(detailsMatchRequest))(any[HeaderCarrier])
       )
         .thenReturn(Future.failed(new MatchingException))
 
@@ -130,7 +130,7 @@ class CitizenMatchingServiceSpec extends SpecBase with Matchers with MockitoSuga
     }
 
     "propagate a citizen not found exception when a nino fails to match a citizen" in new Setup {
-      when(mockNinoMatchRepository.read(matchId)).thenReturn(Future.successful(Some(ninoMatch)))
+      when(mockNinoMatchRepository.read(eqTo(matchId))).thenReturn(Future.successful(Some(ninoMatch)))
       when(mockCitizenDetailsConnector.citizenDetails(ninoString)).thenThrow(new CitizenNotFoundException)
       intercept[CitizenNotFoundException] {
         await(liveService.fetchCitizenDetailsByMatchId(matchId))
@@ -138,7 +138,7 @@ class CitizenMatchingServiceSpec extends SpecBase with Matchers with MockitoSuga
     }
 
     "return citizen details when a match id matches a nino which matches a citizen" in new Setup {
-      when(mockNinoMatchRepository.read(matchId)).thenReturn(Future.successful(Some(ninoMatch)))
+      when(mockNinoMatchRepository.read(eqTo(matchId))).thenReturn(Future.successful(Some(ninoMatch)))
       when(mockCitizenDetailsConnector.citizenDetails(ninoString)).thenReturn(Future.successful(citizenDetails()))
       await(liveService.fetchCitizenDetailsByMatchId(matchId)) shouldBe citizenDetails()
     }
@@ -149,7 +149,7 @@ class CitizenMatchingServiceSpec extends SpecBase with Matchers with MockitoSuga
 
     "return a matched citizen record for a valid matchId" in new Setup {
       val matchedCitizenRecord: MatchedCitizenRecord = MatchedCitizenRecord(Nino(ninoString), matchId)
-      when(mockNinoMatchRepository.read(matchId)).thenReturn(Future.successful(Some(ninoMatch)))
+      when(mockNinoMatchRepository.read(eqTo(matchId))).thenReturn(Future.successful(Some(ninoMatch)))
 
       val result: MatchedCitizenRecord = await(liveService.fetchMatchedCitizenRecord(matchId))
       result shouldBe matchedCitizenRecord

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/services/PathTreeSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/services/PathTreeSpec.scala
@@ -16,13 +16,13 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.services
 
-import org.mockito.IdiomaticMockito
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.individualsmatchingapi.services.PathTree
 
-class PathTreeSpec extends AnyWordSpec with Matchers with IdiomaticMockito with BeforeAndAfterEach {
+class PathTreeSpec extends AnyWordSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
 
   "PathTree" should {
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/util/Individuals.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/util/Individuals.scala
@@ -16,8 +16,9 @@
 
 package unit.uk.gov.hmrc.individualsmatchingapi.util
 
-import java.time.LocalDate.parse
 import uk.gov.hmrc.individualsmatchingapi.domain.CitizenDetails
+
+import java.time.LocalDate.parse
 
 trait Individuals {
 

--- a/test/unit/uk/gov/hmrc/individualsmatchingapi/util/UuidValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsmatchingapi/util/UuidValidatorSpec.scala
@@ -28,13 +28,13 @@ class UuidValidatorSpec extends SpecBase with Matchers with ScalaCheckPropertyCh
   private val invalidUuid = "0-0-0-0-0"
 
   "Return true on a valid lower-cased UUID" in {
-    forAll { uuid: UUID =>
+    forAll { (uuid: UUID) =>
       UuidValidator.validate(uuid.toString) shouldBe true
     }
   }
 
   "Return true on a valid upper-cased UUID" in {
-    forAll { uuid: UUID =>
+    forAll { (uuid: UUID) =>
       UuidValidator.validate(uuid.toString.toUpperCase) shouldBe true
     }
   }


### PR DESCRIPTION
- [x] 1. Dependency upgraded 
- [x] 2. test suite upgraded
- [x] 3. Scala version upgraded
- [x] 4. validated code coverage
- [x] 5. Ran AT's aginst above changes

```
[info]     Then they should receive the correct Employments PAYE data in response 
[info]   Scenario: RP2 journey through Auth, **Individuals Matching and Individuals Employments**
[info]     Given an authorised RP2 user generates a bearer token 
[info]     When they Post a JSON payload of an individual's details to Individuals Matching to retrieve a valid MatchId 
[info]     Then they should receive a valid MatchId in response 
[info]     When they make a GET request to Individuals Matching using that valid MatchId 
[info]     Then they should receive a record of the same individual in response 
[info]     When they make a Get request to Individuals Employments entrypoint 
[info]     Then they should receive the correct HATEOAS links in response 
[info]     When they make a Get request to Individuals Employments PAYE endpoint 
[info]     Then they should receive the correct Employments PAYE data in response 
[info] OrganisationsDetailsVATSpec:
[info] Feature: Organisations Details API VAT Steps
[info] Run completed in 12 seconds, 397 milliseconds.
[info] Total number of tests run: 39
[info] Suites: completed 7, aborted 0
[info] Tests: succeeded 39, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 13 s, completed 16 Apr 2025, 12:30:09
```


- [ ]  6. Ran PT against to latest code changes

