### PR TITLE
DLS-11765 | Add HO NRC scope for matching endpoints

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -145,6 +145,7 @@ api {
 
 api-config {
     scopes {
+        "read:individuals-employments-ho-nrc" { endpoints: ["C", "D"] }
         "read:individuals-matching-laa-c1" { endpoints: ["A", "C", "D"] }
         "read:individuals-matching-laa-c2" { endpoints: ["A", "C", "D"] }
         "read:individuals-matching-laa-c3" { endpoints: ["A", "B", "C", "D"] }

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
@@ -44,6 +44,7 @@ class PrivilegedCitizenMatchingControllerSpec extends BaseSpec {
 
   // Scopes list MUST be in alphabetical order
   val scopes = List(
+    "read:individuals-employments-ho-nrc",
     "read:individuals-matching-hmcts-c2",
     "read:individuals-matching-hmcts-c3",
     "read:individuals-matching-hmcts-c4",

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
@@ -30,6 +30,7 @@ class PrivilegedIndividualsControllerSpec extends BaseSpec {
 
   // Scopes list MUST be in alphabetical order
   val scopes = List(
+    "read:individuals-employments-ho-nrc",
     "read:individuals-matching-hmcts-c2",
     "read:individuals-matching-hmcts-c3",
     "read:individuals-matching-hmcts-c4",


### PR DESCRIPTION
- Include employments scope to provide access to match endpoints. 

_Breaking away from the pattern of bloat with scopes where scopes are tightly coupled with applications. Ideally scopes are meant to be API provided logical grouping of endpoints/data-points (like `read:individual-employment-details`) which should encompass required access points across datasets. That way the scope can be allocated to applications requiring it. atm it's driven the otherway around and not ideal and requires redundant setup every time there is a new application. Something will be discussing with wider group._