### PR TITLE
DLS-11765 | Update to HO NRC scope for matching endpoints

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -145,7 +145,6 @@ api {
 
 api-config {
     scopes {
-        "read:individuals-employments-ho-nrc" { endpoints: ["C", "D"] }
         "read:individuals-matching-laa-c1" { endpoints: ["A", "C", "D"] }
         "read:individuals-matching-laa-c2" { endpoints: ["A", "C", "D"] }
         "read:individuals-matching-laa-c3" { endpoints: ["A", "B", "C", "D"] }
@@ -159,6 +158,7 @@ api-config {
         "read:individuals-matching-ho-rp2" { endpoints: ["C"] }
         "read:individuals-matching-ho-ecp" { endpoints: ["C", "D"] }
         "read:individuals-matching-ho-v2" { endpoints: ["C", "D"] }
+        "read:individuals-matching-ho-nrc" { endpoints: ["C", "D"] }
     }
     endpoints {
         external {

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedCitizenMatchingControllerSpec.scala
@@ -44,11 +44,11 @@ class PrivilegedCitizenMatchingControllerSpec extends BaseSpec {
 
   // Scopes list MUST be in alphabetical order
   val scopes = List(
-    "read:individuals-employments-ho-nrc",
     "read:individuals-matching-hmcts-c2",
     "read:individuals-matching-hmcts-c3",
     "read:individuals-matching-hmcts-c4",
     "read:individuals-matching-ho-ecp",
+    "read:individuals-matching-ho-nrc",
     "read:individuals-matching-ho-rp2",
     "read:individuals-matching-ho-v2",
     "read:individuals-matching-laa-c1",

--- a/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsmatchingapi/controllers/v2/PrivilegedIndividualsControllerSpec.scala
@@ -30,11 +30,11 @@ class PrivilegedIndividualsControllerSpec extends BaseSpec {
 
   // Scopes list MUST be in alphabetical order
   val scopes = List(
-    "read:individuals-employments-ho-nrc",
     "read:individuals-matching-hmcts-c2",
     "read:individuals-matching-hmcts-c3",
     "read:individuals-matching-hmcts-c4",
     "read:individuals-matching-ho-ecp",
+    "read:individuals-matching-ho-nrc",
     "read:individuals-matching-ho-rp2",
     "read:individuals-matching-ho-v2",
     "read:individuals-matching-laa-c1",


### PR DESCRIPTION
- Constrained by how the end user applications are provisioned. So, renaming to use matching scope.